### PR TITLE
[Breaking change] Lift NuGet min client version to 3.5

### DIFF
--- a/SQLite.nuspec
+++ b/SQLite.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata minClientVersion="2.12">
+  <metadata minClientVersion="3.5">
     <id>SQLite</id>
     <version>$version$</version>
     <authors>SQLite Development Team</authors>


### PR DESCRIPTION
Resolves issue with UWP projects getting the wrong native asset when using NuGet 3.4. 
Fix https://github.com/aspnet/EntityFramework/issues/7040.

This is a breaking change with severe implications: the following IDEs will not work

Visual Studio 2015 without manual upgrade of NuGet from https://dist.nuget.org. (default installation uses 3.4.4)
Visual Studio 2013  (uses 2.12)
Xamarin Studio 6.1.2 (uses 3.4.3)

IDE's that will work
VS 2015 with manual upgrade of NuGet.
VS 2017.
Visual Studio for Mac.
.NET Core CLI > 1.0.0-preview2

Until IDE's upgrade, we recommend older versions of the package such as 3.12.3.

cc @ajcvickers @romiller @bricelam @divega
